### PR TITLE
Merge patches from Torotil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ if __name__ == "__main__":
         url="https://github.com/edelooff/sqlalchemy-json",
         packages=find_packages(),
         install_requires=[
-            'sqlalchemy>=0.7'
+            'sqlalchemy>=0.7',
+            'sqlalchemy_utils',
         ],
         zip_safe=False,
         classifiers=[

--- a/sqlalchemy_json/alchemy.py
+++ b/sqlalchemy_json/alchemy.py
@@ -1,31 +1,45 @@
-# Third-party modules
-try:
-  import simplejson as json
-except ImportError:
-  import json
-
-import sqlalchemy
-from sqlalchemy.ext import mutable
+from sqlalchemy.ext.mutable import (
+    Mutable,
+    MutableDict)
 from sqlalchemy_utils.types.json import JSONType
 
-# Custom modules
-from . import track
+from . track import (
+    TrackedDict,
+    TrackedList)
 
 
-class NestedMutable(mutable.MutableDict, track.TrackedDict):
-  """SQLAlchemy `mutable` extension dictionary with nested change tracking."""
-  def __setitem__(self, key, value):
-    """Ensure that items set are converted to change-tracking types."""
-    super(NestedMutable, self).__setitem__(key, self.convert(value, self))
+class NestedMutableDict(TrackedDict, Mutable):
+    @classmethod
+    def coerce(cls, key, value):
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, dict):
+            return cls(value)
+        return super(cls).coerce(key, value)
 
-  @classmethod
-  def coerce(cls, key, value):
-    """Convert plain dictionary to NestedMutable."""
-    if isinstance(value, cls):
-      return value
-    if isinstance(value, dict):
-      return cls(value)
-    return super(cls).coerce(key, value)
+
+class NestedMutableList(TrackedList, Mutable):
+    @classmethod
+    def coerce(cls, key, value):
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, list):
+            return cls(value)
+        return super(cls).coerce(key, value)
+
+
+class NestedMutable(Mutable):
+    """SQLAlchemy `mutable` extension with nested change tracking."""
+    @classmethod
+    def coerce(cls, key, value):
+        """Convert plain dictionary to NestedMutable."""
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, dict):
+            return NestedMutableDict.coerce(key, value)
+        if isinstance(value, list):
+            return NestedMutableList.coerce(key, value)
+        return super(cls).coerce(key, value)
 
 
 class JsonObject(JSONType):
@@ -36,5 +50,5 @@ class NestedJsonObject(JSONType):
   """JSON object type for SQLAlchemy with nested change tracking."""
 
 
-mutable.MutableDict.associate_with(JsonObject)
+MutableDict.associate_with(JsonObject)
 NestedMutable.associate_with(NestedJsonObject)

--- a/sqlalchemy_json/alchemy.py
+++ b/sqlalchemy_json/alchemy.py
@@ -6,6 +6,7 @@ except ImportError:
 
 import sqlalchemy
 from sqlalchemy.ext import mutable
+from sqlalchemy_utils.types.json import JSONType
 
 # Custom modules
 from . import track
@@ -27,22 +28,11 @@ class NestedMutable(mutable.MutableDict, track.TrackedDict):
     return super(cls).coerce(key, value)
 
 
-class _JsonTypeDecorator(sqlalchemy.TypeDecorator):
-  """Enables JSON storage by encoding and decoding on the fly."""
-  impl = sqlalchemy.String
-
-  def process_bind_param(self, value, dialect):
-    return json.dumps(value)
-
-  def process_result_value(self, value, dialect):
-    return json.loads(value)
-
-
-class JsonObject(_JsonTypeDecorator):
+class JsonObject(JSONType):
   """JSON object type for SQLAlchemy with change tracking as base level."""
 
 
-class NestedJsonObject(_JsonTypeDecorator):
+class NestedJsonObject(JSONType):
   """JSON object type for SQLAlchemy with nested change tracking."""
 
 

--- a/sqlalchemy_json/track.py
+++ b/sqlalchemy_json/track.py
@@ -61,10 +61,9 @@ class TrackedObject(object):
     If its type does not occur in the registered types mapping, the object
     is returned unchanged.
     """
-    obj_type = type(obj)
-    for origin_type, replacement in cls._type_mapping.iteritems():
-      if obj_type is origin_type:
-        new = replacement(obj)
+    replacement_type = cls._type_mapping.get(type(obj))
+    if replacement_type is not None:
+        new = replacement_type(obj)
         new.parent = parent
         return new
     return obj
@@ -75,16 +74,16 @@ class TrackedObject(object):
     return (cls.convert(item, parent) for item in iterable)
 
   @classmethod
-  def convert_iteritems(cls, iteritems, parent):
+  def convert_items(cls, items, parent):
     """Returns a generator like `convert_iterable` for 2-tuple iterators."""
-    return ((key, cls.convert(value, parent)) for key, value in iteritems)
+    return ((key, cls.convert(value, parent)) for key, value in items)
 
   @classmethod
   def convert_mapping(cls, mapping, parent):
     """Convenience method to track either a dict or a 2-tuple iterator."""
     if isinstance(mapping, dict):
-      return cls.convert_iteritems(mapping.iteritems(), parent)
-    return cls.convert_iteritems(mapping, parent)
+      return cls.convert_items(mapping.items(), parent)
+    return cls.convert_items(mapping, parent)
 
   def _repr(self):
     """Simple object representation."""

--- a/sqlalchemy_json/track.py
+++ b/sqlalchemy_json/track.py
@@ -7,9 +7,10 @@ A function for automatic conversion of dicts and lists to their tracked
 counterparts is also included.
 """
 
-# Standard modules
 import itertools
 import logging
+
+from sqlalchemy.ext.mutable import Mutable
 
 
 class TrackedObject(object):
@@ -18,8 +19,8 @@ class TrackedObject(object):
 
   def __init__(self, *args, **kwds):
     self.logger = logging.getLogger(type(self).__name__)
-    self.logger.debug('%s: __init__', self._repr())
     self.parent = None
+    self.logger.debug('%s: __init__', self._repr())
     super(TrackedObject, self).__init__(*args, **kwds)
 
   def changed(self, message=None, *args):
@@ -35,6 +36,8 @@ class TrackedObject(object):
     self.logger.debug('%s: changed', self._repr())
     if self.parent is not None:
       self.parent.changed()
+    elif isinstance(self, Mutable):
+      super(TrackedObject, self).changed()
 
   @classmethod
   def register(cls, origin_type):


### PR DESCRIPTION
This merges back a number of (modified) patches by @torotil from his [fork](https://github.com/torotil/sqlalchemy-json). The changes include:

* Using the SQLAlchemy utils provided JSONType for better compatibility and completeness (this resolves #3);
* Updating lookup and iteration code to be Python3 compatible;
* Allow the top level container to be a `list` in addition to a `dict`.