### PR TITLE
Fix error when setting JSON value to be `None`

### DIFF
--- a/sqlalchemy_json/__init__.py
+++ b/sqlalchemy_json/__init__.py
@@ -35,6 +35,8 @@ class NestedMutable(Mutable):
     @classmethod
     def coerce(cls, key, value):
         """Convert plain dictionary to NestedMutable."""
+        if value is None:
+            return value
         if isinstance(value, cls):
             return value
         if isinstance(value, dict):


### PR DESCRIPTION
Previously this would raise an attribute error as `None` does not
have the `coerce` attribute.