### PR TITLE
remove logging

### DIFF
--- a/sqlalchemy_json/track.py
+++ b/sqlalchemy_json/track.py
@@ -20,7 +20,6 @@ class TrackedObject(object):
     def __init__(self, *args, **kwds):
         self.logger = logging.getLogger(type(self).__name__)
         self.parent = None
-        self.logger.debug('%s: __init__', self._repr())
         super(TrackedObject, self).__init__(*args, **kwds)
 
     def changed(self, message=None, *args):
@@ -33,7 +32,6 @@ class TrackedObject(object):
         """
         if message is not None:
             self.logger.debug('%s: %s', self._repr(), message % args)
-        self.logger.debug('%s: changed', self._repr())
         if self.parent is not None:
             self.parent.changed()
         elif isinstance(self, Mutable):


### PR DESCRIPTION
Closes #16.

I kept the logging in the case of `TrackedObject.change` when the arg `message` is passed, to keep backward compatibility (nothing else is done with `message`).