### PR TITLE
Switch to sqlalchemy.types.JSON

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,6 @@ Had the articles model used ``MutableJson`` like in the previous example this co
 Dependencies
 ============
 
-* ``SQLAlchemy-utils`` for its existing and database-engine specific choice of either native or simulated JSON type;
 * ``six`` to support both Python 2 and 3.
 
 
@@ -76,6 +75,11 @@ Changelog
 
 * Fixes a bug where assigning ``None`` to the column resulted in an error (https://github.com/edelooff/sqlalchemy-json/issues/10)
 
+
+0.3.0
+-----
+
+* Switch to sqlalchemy.types.JSON and remove SQLAlchemy-utils
 
 0.2.1
 -----
@@ -99,4 +103,3 @@ Initial version. This initially carried a 1.0.0 version number but has never bee
 
 .. _mutable json recipe: http://docs.sqlalchemy.org/en/latest/core/custom_types.html#marshal-json-strings
 .. _sqlalchemy: https://www.sqlalchemy.org/
-.. _sqlalchemy-utils: https://sqlalchemy-utils.readthedocs.io/

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def contents(filename):
 
 setup(
     name='sqlalchemy-json',
-    version='0.2.3',
+    version='0.3.0',
     author='Elmer de Looff',
     author_email='elmer.delooff@gmail.com',
     description='JSON type with nested change tracking for SQLAlchemy',
@@ -21,8 +21,7 @@ setup(
     packages=['sqlalchemy_json'],
     install_requires=[
         'six',
-        'sqlalchemy>=0.7',
-        'sqlalchemy_utils'],
+        'sqlalchemy>=0.7'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/sqlalchemy_json/__init__.py
+++ b/sqlalchemy_json/__init__.py
@@ -1,7 +1,7 @@
 from sqlalchemy.ext.mutable import (
     Mutable,
     MutableDict)
-from sqlalchemy_utils.types.json import JSONType
+from sqlalchemy.types import JSON
 
 from . track import (
     TrackedDict,
@@ -46,11 +46,11 @@ class NestedMutable(Mutable):
         return super(cls).coerce(key, value)
 
 
-class MutableJson(JSONType):
+class MutableJson(JSON):
     """JSON type for SQLAlchemy with change tracking at top level."""
 
 
-class NestedMutableJson(JSONType):
+class NestedMutableJson(JSON):
     """JSON type for SQLAlchemy with nested change tracking."""
 
 

--- a/sqlalchemy_json/track.py
+++ b/sqlalchemy_json/track.py
@@ -13,12 +13,14 @@ from six import iteritems
 from sqlalchemy.ext.mutable import Mutable
 
 
+logger = logging.getLogger(__name__)
+
+
 class TrackedObject(object):
     """A base class for delegated change-tracking."""
     _type_mapping = {}
 
     def __init__(self, *args, **kwds):
-        self.logger = logging.getLogger(type(self).__name__)
         self.parent = None
         super(TrackedObject, self).__init__(*args, **kwds)
 
@@ -31,8 +33,8 @@ class TrackedObject(object):
         The message (if provided) will be debug logged.
         """
         if message is not None:
-            self.logger.debug('%s: %s', self._repr(), message % args)
-        self.logger.debug('%s: changed', self._repr())
+            logger.debug('%s: %s', self._repr(), message % args)
+        logger.debug('%s: changed', self._repr())
         if self.parent is not None:
             self.parent.changed()
         elif isinstance(self, Mutable):


### PR DESCRIPTION
Per #22 and https://github.com/kvesteri/sqlalchemy-utils/issues/164#issuecomment-171681943  sqlalchemy_utils.types.json.JSONType is not to be used anymore 