### PR TITLE
Fix list.sort() argument passing

### DIFF
--- a/sqlalchemy_json/track.py
+++ b/sqlalchemy_json/track.py
@@ -169,6 +169,6 @@ class TrackedList(TrackedObject, list):
         self.changed('pop: %d', index)
         return super(TrackedList, self).pop(index)
 
-    def sort(self, cmp=None, key=None, reverse=False):
+    def sort(self, /, *, key=None, reverse=False):
         self.changed('sort')
-        super(TrackedList, self).sort(cmp=cmp, key=key, reverse=reverse)
+        super(TrackedList, self).sort(key=key, reverse=reverse)

--- a/sqlalchemy_json/track.py
+++ b/sqlalchemy_json/track.py
@@ -169,6 +169,6 @@ class TrackedList(TrackedObject, list):
         self.changed('pop: %d', index)
         return super(TrackedList, self).pop(index)
 
-    def sort(self, /, *, key=None, reverse=False):
+    def sort(self, *, key=None, reverse=False):
         self.changed('sort')
         super(TrackedList, self).sort(key=key, reverse=reverse)


### PR DESCRIPTION
The `cmp` keyword doesn't exist anymore, and so fails with
```
...
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/datatypes/mothur.py", line 78, in set_meta
    dataset.metadata.labels.sort()
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/sqlalchemy_json/track.py", line 174, in sort
    super(TrackedList, self).sort(cmp=cmp, key=key, reverse=reverse)
TypeError: sort() takes at most 2 keyword arguments (3 given)
```