### PR TITLE
Add support for tracking dict merging (Python 3.9)

### DIFF
--- a/sqlalchemy_json/track.py
+++ b/sqlalchemy_json/track.py
@@ -103,6 +103,10 @@ class TrackedDict(TrackedObject, dict):
             self.convert_mapping(source),
             self.convert_mapping(kwds)))
 
+    def __ior__(self, other):
+        self.changed('__ior__: %r', other)
+        return super(TrackedDict, self).__ior__(self.convert(other, self))
+
     def __setitem__(self, key, value):
         self.changed('__setitem__: %r=%r', key, value)
         super(TrackedDict, self).__setitem__(key, self.convert(value, self))

--- a/test/test_sqlalchemy_json.py
+++ b/test/test_sqlalchemy_json.py
@@ -1,4 +1,5 @@
 import pickle
+import sys
 
 import pytest
 
@@ -104,6 +105,7 @@ def test_nested_pickling():
     assert one_reloaded is not two_reloaded
 
 
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="Python 3.9+ required")
 def test_dict_merging(session, article):
     article.references['github.com'] |= {'someone/somerepo': 10}
     session.commit()

--- a/test/test_sqlalchemy_json.py
+++ b/test/test_sqlalchemy_json.py
@@ -102,3 +102,15 @@ def test_nested_pickling():
     assert one_reloaded["numbers"].parent is one_reloaded
     assert two_reloaded["numbers"].parent is two_reloaded
     assert one_reloaded is not two_reloaded
+
+
+def test_dict_merging(session, article):
+    article.references['github.com'] |= {'someone/somerepo': 10}
+    session.commit()
+    assert article.references == {
+        'github.com': {
+            'edelooff/sqlalchemy-json': 4,
+            'zzzeek/sqlalchemy': [1, 2, 3],
+            'someone/somerepo': 10,
+        },
+    }


### PR DESCRIPTION
Python 3.9 introduced in-place merging of one dictionary into another via `|=` (operator `__ior__`). This RP fixes an issue where changes made via `|=` aren't detected.

See also: https://www.python.org/dev/peps/pep-0584/#specification