### PR TITLE
Fix invalid syntax in Python 2

### DIFF
--- a/sqlalchemy_json/track.py
+++ b/sqlalchemy_json/track.py
@@ -180,6 +180,6 @@ class TrackedList(TrackedObject, list):
         self.changed("pop: %d", index)
         return super(TrackedList, self).pop(index)
 
-    def sort(self, *, key=None, reverse=False):
+    def sort(self, *args, key=None, reverse=False):
         self.changed("sort")
         super(TrackedList, self).sort(key=key, reverse=reverse)


### PR DESCRIPTION
Hi, I've seen in [PyPi](https://pypi.org/project/sqlalchemy-json/) that the library is compatible with Python 2, yet, I'm having this invalid syntax error due to Python 2 does not support keyword-only arguments.