### PR TITLE
Support pickling when Mutable._parents exists

### DIFF
--- a/sqlalchemy_json/__init__.py
+++ b/sqlalchemy_json/__init__.py
@@ -6,7 +6,14 @@ from .track import TrackedDict, TrackedList
 __all__ = "MutableJson", "NestedMutableJson", "mutable_json_type"
 
 
-class NestedMutableDict(TrackedDict, Mutable):
+class _PickleMixin:
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        d.pop("_parents", None)
+        return d
+
+
+class NestedMutableDict(TrackedDict, Mutable, _PickleMixin):
     @classmethod
     def coerce(cls, key, value):
         if isinstance(value, cls):
@@ -16,7 +23,7 @@ class NestedMutableDict(TrackedDict, Mutable):
         return super(cls).coerce(key, value)
 
 
-class NestedMutableList(TrackedList, Mutable):
+class NestedMutableList(TrackedList, Mutable, _PickleMixin):
     @classmethod
     def coerce(cls, key, value):
         if isinstance(value, cls):

--- a/test/test_sqlalchemy_json.py
+++ b/test/test_sqlalchemy_json.py
@@ -103,6 +103,11 @@ def test_nested_change_tracking(session, article):
 def test_nested_pickling():
     one = NestedMutableDict({"numbers": [1, 2, 3, 4]})
     two = NestedMutableDict({"numbers": [5, 6, 7]})
+    
+    # Force _parents WeakKeyDict creation
+    one._parents
+    two._parents
+    
     one_reloaded = pickle.loads(pickle.dumps(one))
     two_reloaded = pickle.loads(pickle.dumps(two))
     assert one == one_reloaded

--- a/test/test_sqlalchemy_json.py
+++ b/test/test_sqlalchemy_json.py
@@ -101,25 +101,29 @@ def test_nested_change_tracking(session, article):
 
 
 def test_nested_pickling():
-    one = NestedMutableDict({"numbers": [1, 2, 3, 4]})
-    two = NestedMutableDict({"numbers": [5, 6, 7]})
-    
-    # Force _parents WeakKeyDict creation
+    one = NestedMutableDict({"numbers": [1, 2, 3, {"4": 4}]})
+    two = NestedMutableList([5, 6, 7, {"numbers": [8, 9, 10]}])
+
+    # Force evaluation of _parents property
     one._parents
     two._parents
-    
+
     one_reloaded = pickle.loads(pickle.dumps(one))
     two_reloaded = pickle.loads(pickle.dumps(two))
     assert one == one_reloaded
     assert two == two_reloaded
 
     one_reloaded["numbers"].append(5)
-    assert one_reloaded["numbers"] == [1, 2, 3, 4, 5]
-    assert one["numbers"] == [1, 2, 3, 4]
-
+    assert one_reloaded["numbers"] == [1, 2, 3, {"4": 4}, 5]
+    assert one["numbers"] == [1, 2, 3, {"4": 4}]
     assert one_reloaded["numbers"].parent is one_reloaded
-    assert two_reloaded["numbers"].parent is two_reloaded
-    assert one_reloaded is not two_reloaded
+    assert one_reloaded["numbers"][3].parent is one_reloaded["numbers"]
+
+    two_reloaded.append(11)
+    assert two_reloaded == [5, 6, 7, {"numbers": [8, 9, 10]}, 11]
+    assert two == [5, 6, 7, {"numbers": [8, 9, 10]}]
+    assert two_reloaded[3].parent is two_reloaded
+    assert two_reloaded[3]["numbers"].parent is two_reloaded[3]
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="Python 3.9+ required")


### PR DESCRIPTION
Hello,

This is a quick fix for #36 in case you find it useful. It just follows the guidelines in [Supporting Pickling docs](https://docs.sqlalchemy.org/en/14/orm/extensions/mutable.html?highlight=supporting+pickling#supporting-picklinghttps://docs.sqlalchemy.org/en/14/orm/extensions/mutable.html?highlight=supporting+pickling#supporting-pickling)

Thanks!